### PR TITLE
Cli opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 When your `package.json` grows, it’s easy to forget what `dev:db:reset` or `build:analyze` actually do.
 Akio helps you keep track of your scripts and their descriptions, right from the terminal.
 
-## Zero Config. No Magic.
+## Optional Config. No Magic.
 
 Akio doesn’t try to run your project or guess what you mean.
 It just reads what’s already there and helps you navigate it faster.
@@ -37,21 +37,36 @@ npx akio
 Inside any Node.js project with a `package.json`:
 
 ```bash
-pnpm akio
+[npm|yarn|pnpm] akio
 # or
 npx akio
 ```
 
 You’ll see a list of scripts like this:
 ```
-pnpm accio
+pnpm akio
         -----
 1. test       — run vitest unit tests
 2. build      — create production build at ./dist with esbuild
 3. accio      — fetch & run script descriptions
+
+Run command number? 
 ```
 
 Pick a number to run it, or just use the list as a reference.
+
+## CLI Options
+Two command line interace options exist:
+1. `--no-input` _or_ `-i` turns off prompting you for a command
+2. `--no-formatting` _or_ `-f` turns off colors (emojis soon)
+
+The easiest way to consume these is via `package.json`:
+```json
+"scripts": {
+    "akio": "npx akio --no-input --no-formatting",
+    ...
+},
+```
 
 ## How to Document Scripts
 
@@ -85,9 +100,8 @@ Akio is great for:
 
 * Support for `jsonc` comments next to scripts
 * Search by script key, or value
-* auto-generation of descriptions for established packages?
-* Terminal colors shut off
-* Execute by number shut off
+* Auto-generation of descriptions for established packages?
+* Turn off emojis when `--no-formatting` CLI opt supplied
 
 ## License
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,8 +421,8 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyglobby@0.2.13:
-    resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
+  tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.0.2:
@@ -828,7 +828,7 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyglobby@0.2.13:
+  tinyglobby@0.2.14:
     dependencies:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
@@ -869,7 +869,7 @@ snapshots:
       picomatch: 4.0.2
       postcss: 8.5.3
       rollup: 4.41.1
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 22.15.21
       fsevents: 2.3.3
@@ -891,7 +891,7 @@ snapshots:
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.14
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
       vite: 6.3.5(@types/node@22.15.21)

--- a/src/cli-opts.ts
+++ b/src/cli-opts.ts
@@ -1,0 +1,25 @@
+import { formatError } from "./format-output";
+
+type CliOptions = {
+    showInput: boolean;
+    showFormatting: boolean;
+};
+
+export function processCliOpts(args = process.argv.slice(2)): CliOptions {
+    let showInput = true;
+    let showFormatting = true;
+
+    const showInputOpts = ['-i', '--no-input'];
+    const showFormattingOpts = ['-f', '--no-formatting'];
+
+    for (const arg of args) {
+        if (!showInputOpts.concat(showFormattingOpts).includes(arg)) {
+            formatError(`Invalid command line option: ${arg}`);
+        }
+
+        if (showInputOpts.includes(arg)) showInput = false;
+        if (showFormattingOpts.includes(arg)) showFormatting = false;
+    }
+
+    return { showInput, showFormatting };
+}

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -4,3 +4,9 @@ export const Colors: Record<string, string> = {
     red: '\x1b[31m',
     reset: '\x1b[0m'
 };
+
+export const disableColors = () => {
+    for(const [key, _] of Object.entries(Colors)) {
+        Colors[key] = '';
+    }
+}

--- a/src/format-output.ts
+++ b/src/format-output.ts
@@ -1,0 +1,8 @@
+import { Colors } from "./colors";
+
+export const formatError = (message: string) => {
+    const errorMsg = `${Colors.red}❌ ERROR: ${message}${Colors.reset}\n`
+    console.error(errorMsg);
+
+    process.exit(1);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,8 @@ const mapAndOutputCommands = (runner: string) => {
     console.log('\t-----');
 
     for (const [name, _] of Object.entries(pkg.scripts)) {
+        if(name === 'akio') continue;
+        
         count++;
 
         const description = pkg.scriptDescriptions[name] ?? '';
@@ -56,7 +58,7 @@ const executeCommand = (commandMap: CommandMap, input: string) => {
         formatError(`Unknown command number: ${input}`);
     }
 
-    const pkgManager = getRunner();
+    const pkgManager = getPkgManager();
 
     const cmd = `${pkgManager} ${commandMap[input]}`;
     const execCallback = (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => {
@@ -77,7 +79,7 @@ const executeCommand = (commandMap: CommandMap, input: string) => {
     exec(cmd, emptyOpts, execCallback);
 };
 
-const getRunner = () => {
+const getPkgManager = () => {
     if (fs.existsSync('pnpm-lock.yaml')) return 'pnpm';
     if (fs.existsSync('yarn.lock')) return 'yarn';
 
@@ -86,11 +88,11 @@ const getRunner = () => {
 
 const main = () => {
     const { showInput, showFormatting } = processCliOpts();
-    const runner = getRunner();
+    const pkgManager = getPkgManager();
 
     if(!showFormatting) disableColors();
 
-    const commandMap = mapAndOutputCommands(runner);
+    const commandMap = mapAndOutputCommands(pkgManager);
 
     if (showInput) processCommand(commandMap);
 };


### PR DESCRIPTION
- add cli opts for 
  - `[-i, --no-input]` - turns off prompted input
  - `[-f, --no-formatting]` - turns off formatting (emojis still present for now)
- easiest way to consume these is via `package.json`:
```
"scripts": {
    "akio": "npx akio --no-input --no-formatting",
    ...
},
```